### PR TITLE
convert build to reusable workflow

### DIFF
--- a/.github/actions/build-marketplace/action.yml
+++ b/.github/actions/build-marketplace/action.yml
@@ -1,0 +1,40 @@
+name: Build Marketplace
+description: Sets up Java, Maven Cache and builds the Marketplace.
+inputs:
+    RUN_TESTS:
+      description: 'Run Maven Tests'
+      default: 'false'
+      required: true
+
+runs:
+  using: composite
+  steps:
+  - uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
+    with:
+      java-version: 21
+      distribution: temurin
+      cache: maven
+
+  - name: Get submodule SHA
+    shell: bash
+    id: get-submodule-sha
+    run: echo "SUBMODULE_SHA=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+    working-directory: api.adoptium.net
+
+  - name: Cache api.adoptium.net packages
+    uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+    id: cache-api
+    with:
+      path: ~/.m2/repository/net/adoptium/api
+      key: maven-repo-${{ steps.get-submodule-sha.outputs.SUBMODULE_SHA }}
+      restore-keys: maven-repo-${{ steps.get-submodule-sha.outputs.SUBMODULE_SHA }}
+
+  - name: Build api
+    shell: bash
+    if: steps.cache-api.outputs.cache-hit != 'true'
+    working-directory: api.adoptium.net
+    run: ./mvnw --batch-mode clean install -Padoptium -DskipTests=${{ inputs.RUN_TESTS }}
+
+  - name: Build marketplace
+    shell: bash
+    run: ./mvnw --batch-mode clean install -DskipTests=${{ inputs.RUN_TESTS }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/build-marketplace"
+    schedule:
+      interval: "daily"
   - package-ecosystem: "maven"
     directory: "/"
     schedule:

--- a/.github/workflows/build-marketplace.yml
+++ b/.github/workflows/build-marketplace.yml
@@ -25,32 +25,8 @@ jobs:
       with:
         submodules: true
 
-    - uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
-      with:
-        java-version: 21
-        distribution: temurin
-        cache: maven
-
-    - name: Get submodule SHA
-      id: get-submodule-sha
-      run: echo "SUBMODULE_SHA=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-      working-directory: api.adoptium.net
-
-    - name: Cache api.adoptium.net packages
-      uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
-      id: cache-api
-      with:
-        path: ~/.m2/repository/net/adoptium/api
-        key: maven-repo-${{ steps.get-submodule-sha.outputs.SUBMODULE_SHA }}
-        restore-keys: maven-repo-${{ steps.get-submodule-sha.outputs.SUBMODULE_SHA }}
-
-    - name: Build api
-      if: steps.cache-api.outputs.cache-hit != 'true'
-      working-directory: api.adoptium.net
-      run: ./mvnw --batch-mode clean install -Padoptium
-
-    - name: Build marketplace
-      run: ./mvnw --batch-mode clean install
+    - name: Build Marketplace
+      uses: ./.github/actions/build-marketplace
 
     - name: Upload yaml schema
       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3

--- a/.github/workflows/run-vendor-validation.yml
+++ b/.github/workflows/run-vendor-validation.yml
@@ -16,32 +16,10 @@ jobs:
         with:
           submodules: true
 
-      - uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
+      - name: Build Marketplace
+        uses: ./.github/actions/build-marketplace
         with:
-          java-version: 21
-          distribution: temurin
-          cache: maven
-
-      - name: Get submodule SHA
-        id: get-submodule-sha
-        run: echo "SUBMODULE_SHA=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-        working-directory: api.adoptium.net
-  
-      - name: Cache api.adoptium.net packages
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
-        id: cache-api
-        with:
-          path: ~/.m2/repository/net/adoptium/api
-          key: maven-repo-${{ steps.get-submodule-sha.outputs.SUBMODULE_SHA }}
-          restore-keys: maven-repo-${{ steps.get-submodule-sha.outputs.SUBMODULE_SHA }}
-
-      - name: Build api
-        if: steps.cache-api.outputs.cache-hit != 'true'
-        working-directory: api.adoptium.net
-        run: ./mvnw --batch-mode clean install -Padoptium -DskipTests
-
-      - name: Build marketplace
-        run: ./mvnw --batch-mode clean install -DskipTests
+          RUN_TESTS: true
 
       - name: Validate vendors
         working-directory: adoptium-marketplace-vendor-validation


### PR DESCRIPTION
Removes duplicate code and also allows us to reuse the workflow in the downstream [marketplace-data](https://github.com/adoptium/marketplace-data) repo.

# Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] You added tests to cover the change
- [x] `mvn clean install` build and test completes
- [ ] You changed or added to the documentation